### PR TITLE
Feature/21 non recusrive tree traversal

### DIFF
--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/BinarySearchComparableTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/BinarySearchComparableTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using Phnx.Collections.Tests.TestHelpers;
+﻿using Phnx.Collections.Tests.TestHelpers;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/BinarySearchTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/BinarySearchTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Drawing;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ClearTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ClearTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/FillTTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/FillTTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/FillTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/FillTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/IndexOfTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/IndexOfTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/LastIndexOfTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/LastIndexOfTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ResizeTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ResizeTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ReverseTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ReverseTests.cs
@@ -1,7 +1,5 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
-using System.Linq;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions
 {

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ShallowCopyTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/ShallowCopyTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/SortTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ArrayExtensions/SortTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToIntTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToIntTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ByteArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToLongTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToLongTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ByteArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToMemoryStreamTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToMemoryStreamTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ByteArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToShortTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ByteArrayExtensions/ToShortTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 
 namespace Phnx.Collections.Tests.Extensions.ByteArrayExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/CopyRangeTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/CopyRangeTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/CopyRangeToEndTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/CopyRangeToEndTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/FillTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/FillTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/ToStringTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableExtensions/ToStringTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/AppendTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/AppendTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/BreadthFirstFlattenTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/BreadthFirstFlattenTests.cs
@@ -1,0 +1,77 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Phnx.Collections.Tests.Extensions.IEnumerableLinqExtensions
+{
+    public class BreadthFirstFlattenTests
+    {
+        private IEnumerable<string> StringSplitter(string s)
+        {
+            if (s.Length <= 1)
+            {
+                yield break;
+            }
+
+            int halfway = s.Length / 2;
+            yield return s.Substring(0, halfway);
+            yield return s.Substring(halfway);
+        }
+
+        [Test]
+        public void BreadthFirstFlatten_WhenSourceIsNull_ThrowsArgumentNullException()
+        {
+            List<string> collection = null;
+
+            Assert.Throws<ArgumentNullException>(() => collection.BreadthFirstFlatten(s => new List<string>(0)).ToList());
+        }
+
+        [Test]
+        public void BreadthFirstFlatten_WhenChildSelectorIsNull_ThrowsArgumentNullException()
+        {
+            var collection = new List<string>(0);
+
+            Assert.Throws<ArgumentNullException>(() => collection.BreadthFirstFlatten(null).ToList());
+        }
+
+        [Test]
+        public void BreadthFirstFlatten_WhenSourceIsEmpty_GetsEmpty()
+        {
+            var expected = new List<string>(0);
+            var collection = new List<string>(0);
+
+            var flattened = collection.BreadthFirstFlatten(StringSplitter);
+
+            CollectionAssert.AreEqual(expected, flattened);
+        }
+
+        [Test]
+        public void BreadthFirstFlatten_WhenSourceIsShallow_GetsShallow()
+        {
+            var expected = new List<string> { "ab", "a", "b" };
+            var collection = new List<string> { "ab" };
+
+            var flattened = collection.BreadthFirstFlatten(StringSplitter);
+
+            CollectionAssert.AreEqual(expected, flattened);
+        }
+
+        [Test]
+        public void BreadthFirstFlatten_WhenSourceIsDeep_GetsBreadthFirst()
+        {
+            var expected = new List<string>
+            {
+                "abcdefgh",
+                "abcd", "efgh", "ab", "cd", "ef", "gh",
+                "a", "b", "c", "d", "e", "f", "g", "h"
+            };
+
+            var collection = new List<string> { "abcdefgh" };
+
+            var flattened = collection.BreadthFirstFlatten(StringSplitter);
+
+            CollectionAssert.AreEqual(expected, flattened);
+        }
+    }
+}

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/DepthFirstFlattenTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/DepthFirstFlattenTests.cs
@@ -1,0 +1,77 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Phnx.Collections.Tests.Extensions.IEnumerableLinqExtensions
+{
+    public class DepthFirstFlattenTests
+    {
+        private IEnumerable<string> StringSplitter(string s)
+        {
+            if (s.Length <= 1)
+            {
+                yield break;
+            }
+
+            int halfway = s.Length / 2;
+            yield return s.Substring(0, halfway);
+            yield return s.Substring(halfway);
+        }
+
+        [Test]
+        public void DepthFirstFlatten_WhenSourceIsNull_ThrowsArgumentNullException()
+        {
+            List<string> collection = null;
+
+            Assert.Throws<ArgumentNullException>(() => collection.DepthFirstFlatten(s => new List<string>(0)).ToList());
+        }
+
+        [Test]
+        public void DepthFirstFlatten_WhenChildSelectorIsNull_ThrowsArgumentNullException()
+        {
+            var collection = new List<string>(0);
+
+            Assert.Throws<ArgumentNullException>(() => collection.DepthFirstFlatten(null).ToList());
+        }
+
+        [Test]
+        public void DepthFirstFlatten_WhenSourceIsEmpty_GetsEmpty()
+        {
+            var expected = new List<string>(0);
+            var collection = new List<string>(0);
+
+            var flattened = collection.DepthFirstFlatten(StringSplitter);
+
+            CollectionAssert.AreEqual(expected, flattened);
+        }
+
+        [Test]
+        public void DepthFirstFlatten_WhenSourceIsShallow_GetsShallow()
+        {
+            var expected = new List<string> { "ab", "a", "b" };
+            var collection = new List<string> { "ab" };
+
+            var flattened = collection.DepthFirstFlatten(StringSplitter);
+
+            CollectionAssert.AreEqual(expected, flattened);
+        }
+
+        [Test]
+        public void DepthFirstFlatten_WhenSourceIsDeep_GetsDepthFirst()
+        {
+            var expected = new List<string>
+            {
+                "abcdefgh",
+                "abcd", "ab", "a", "b", "cd", "c", "d",
+                "efgh", "ef", "e", "f", "gh", "g", "h"
+            };
+
+            var collection = new List<string> { "abcdefgh" };
+
+            var flattened = collection.DepthFirstFlatten(StringSplitter);
+
+            CollectionAssert.AreEqual(expected, flattened);
+        }
+    }
+}

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/DistinctByTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/DistinctByTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/EqualsRangeTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/EqualsRangeTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 
 namespace Phnx.Collections.Tests.Extensions.IEnumerableLinqExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/FlattenTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/FlattenTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/IndexOfLongTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/IndexOfLongTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/IndexOfTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/IndexOfTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/MaxByTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/MaxByTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/MinByTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/MinByTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/ToListTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumerableLinqExtensions/ToListTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IEnumeratorExtensionsTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IEnumeratorExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/BinarySearchComparableTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/BinarySearchComparableTests.cs
@@ -1,6 +1,5 @@
-﻿using Phnx.Collections.Extensions;
+﻿using NUnit.Framework;
 using Phnx.Collections.Tests.TestHelpers;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/BinarySearchTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/BinarySearchTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/EqualsRangeTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/EqualsRangeTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
 
 namespace Phnx.Collections.Tests.Extensions.IListExtensions

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/FillTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/FillTests.cs
@@ -1,8 +1,6 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Phnx.Collections.Tests.Extensions.IListExtensions
 {

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/LastTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/LastTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/ToListTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/IListExtensions/ToListTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Extensions/ListExtensionsTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Extensions/ListExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Extensions;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/Collections/Phnx.Collections.Tests/Tree/TreeTests.cs
+++ b/src/Collections/Phnx.Collections.Tests/Tree/TreeTests.cs
@@ -1,5 +1,4 @@
-﻿using Phnx.Collections.Tree;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace Phnx.Collections.Tests.Tree
 {

--- a/src/Collections/Phnx.Collections/Extensions/ArrayExtensions.cs
+++ b/src/Collections/Phnx.Collections/Extensions/ArrayExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Phnx.Collections.Extensions
+namespace Phnx.Collections
 {
     /// <summary>
     /// Extension for <see cref="Array"/>

--- a/src/Collections/Phnx.Collections/Extensions/ByteArrayExtensions.cs
+++ b/src/Collections/Phnx.Collections/Extensions/ByteArrayExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 
-namespace Phnx.Collections.Extensions
+namespace Phnx.Collections
 {
     /// <summary>
     /// Extensions for <see cref="T:byte[]"/>

--- a/src/Collections/Phnx.Collections/Extensions/IEnumerableExtensions.cs
+++ b/src/Collections/Phnx.Collections/Extensions/IEnumerableExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Phnx.Collections.Extensions
+namespace Phnx.Collections
 {
     /// <summary>
     /// Extensions for <see cref="IEnumerable{T}"/>

--- a/src/Collections/Phnx.Collections/Extensions/IEnumeratorExtensions.cs
+++ b/src/Collections/Phnx.Collections/Extensions/IEnumeratorExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Phnx.Collections.Extensions
+namespace Phnx.Collections
 {
     /// <summary>
     /// Extensions for <see cref="IEnumerator{T}"/>

--- a/src/Collections/Phnx.Collections/Extensions/IListExtensions.cs
+++ b/src/Collections/Phnx.Collections/Extensions/IListExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Phnx.Collections.Extensions
+namespace Phnx.Collections
 {
     /// <summary>
     /// Extensions for <see cref="IList{T}"/>

--- a/src/Collections/Phnx.Collections/Extensions/ListExtensions.cs
+++ b/src/Collections/Phnx.Collections/Extensions/ListExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Phnx.Collections.Extensions
+namespace Phnx.Collections
 {
     /// <summary>
     /// Extensions for <see cref="List{T}"/>

--- a/src/Collections/Phnx.Collections/Tree/Tree.cs
+++ b/src/Collections/Phnx.Collections/Tree/Tree.cs
@@ -1,14 +1,14 @@
-﻿using Phnx.Collections.Extensions;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Phnx.Collections.Tree
+namespace Phnx.Collections
 {
     /// <summary>
     /// Manages a tree data structure of values, with each node having a many-to-many relationship with other nodes
     /// </summary>
     /// <typeparam name="T">The type of data to store in the tree</typeparam>
-    public class Tree<T>
+    public class Tree<T> : IEnumerable<T>
     {
         private readonly List<TreeNode<T>> _topNodes;
 
@@ -35,7 +35,7 @@ namespace Phnx.Collections.Tree
         }
 
         /// <summary>
-        /// Get all data nodes in the tree
+        /// Get all data nodes in the tree, depth first. Each node is only returned once, so if a node has two parents, it only appears once in the result
         /// </summary>
         public IEnumerable<TreeNode<T>> AllNodes
         {
@@ -72,6 +72,42 @@ namespace Phnx.Collections.Tree
             _topNodes.Add(newNode);
 
             return newNode;
+        }
+
+        /// <summary>
+        /// Gets all nodes in the tree, depth first. This can contain duplicate nodes if two parents refer to the same node
+        /// </summary>
+        /// <returns>All nodes in the tree, depth first. This can contain duplicate nodes if two parents refer to the same node</returns>
+        public IEnumerable<T> TraverseDepthFirst()
+        {
+            return
+                TopNodes.DepthFirstFlatten(node => node.Children)
+                .Select(n => n.Value);
+        }
+
+        /// <summary>
+        /// Gets all nodes in the tree, breadth first. This can contain duplicate nodes if two parents refer to the same node
+        /// </summary>
+        /// <returns>All nodes in the tree, breadth first. This can contain duplicate nodes if two parents refer to the same node</returns>
+        public IEnumerable<T> TraverseBreadthFirst()
+        {
+            return
+                TopNodes.BreadthFirstFlatten(node => node.Children)
+                .Select(n => n.Value);
+        }
+
+        /// <summary>
+        /// Returns an enumerator for the <see cref="TopNodes"/> values. To traverse the entire tree, use <see cref="AllNodes"/>, <see cref="TraverseDepthFirst"/> or <see cref="TraverseBreadthFirst"/>
+        /// </summary>
+        /// <returns>An enumerator for the <see cref="TopNodes"/> values</returns>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return TopNodes.Select(n => n.Value).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Collections/Phnx.Collections/Tree/TreeNode.cs
+++ b/src/Collections/Phnx.Collections/Tree/TreeNode.cs
@@ -1,8 +1,7 @@
-﻿using Phnx.Collections.Extensions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Phnx.Collections.Tree
+namespace Phnx.Collections
 {
     /// <summary>
     /// A node of data within a <see cref="Tree{T}"/>

--- a/src/Drawing/Phnx.Drawing/Hex.cs
+++ b/src/Drawing/Phnx.Drawing/Hex.cs
@@ -1,4 +1,4 @@
-﻿using Phnx.Collections.Extensions;
+﻿using Phnx.Collections;
 using System;
 using System.Drawing;
 using System.Text;

--- a/src/IO/Json/Phnx.IO.Json/Streams/JsonReadStream.cs
+++ b/src/IO/Json/Phnx.IO.Json/Streams/JsonReadStream.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Phnx.IO.Extensions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -84,11 +83,6 @@ namespace Phnx.IO.Json.Streams
         {
             return JObjectConverter.ToJson(JObject.Load(Reader));
         }
-
-        /// <summary>
-        /// Whether the end of the stream has been reached
-        /// </summary>
-        public bool ReachedEnd => TextReader.ReachedEnd();
 
         /// <summary>
         /// Dispose of this reader, and close the stream if specified


### PR DESCRIPTION
Added new `BreadthFirstFlatten` and `DepthFirstFlatten` to `IEnumerableLinqExtensions` in Collections.
Also removed legacy Extensions namespace, and updated usages (only in already refactored libraries)